### PR TITLE
IoT endpoints

### DIFF
--- a/src/main/java/no/haugalandplus/val/entities/Poll.java
+++ b/src/main/java/no/haugalandplus/val/entities/Poll.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 import lombok.Setter;
 import no.haugalandplus.val.constants.PollStatusEnum;
 
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
@@ -35,4 +36,7 @@ public class Poll {
     @OneToMany(cascade = CascadeType.ALL)
     @JoinColumn(name = "choice_poll_id")
     private List<Choice> choices;
+
+    @OneToMany
+    private List<User> iotList = new ArrayList<>();
 }

--- a/src/main/java/no/haugalandplus/val/rest/IoTController.java
+++ b/src/main/java/no/haugalandplus/val/rest/IoTController.java
@@ -1,0 +1,27 @@
+package no.haugalandplus.val.rest;
+
+import no.haugalandplus.val.service.IoTService;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class IoTController {
+
+    private IoTService iotService;
+
+    public IoTController(IoTService iotService) {
+        this.iotService = iotService;
+    }
+
+    @PostMapping("polls/{poll-id}/iot")
+    public ResponseEntity<String> connectToPoll(@PathVariable("poll-id") Long id) {
+        String token = iotService.addIotToPoll(id);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Authorization", token);
+        return ResponseEntity.ok().headers(headers).body(token);
+    }
+}

--- a/src/main/java/no/haugalandplus/val/service/IoTService.java
+++ b/src/main/java/no/haugalandplus/val/service/IoTService.java
@@ -1,0 +1,53 @@
+package no.haugalandplus.val.service;
+
+import no.haugalandplus.val.auth.JwtTokenUtil;
+import no.haugalandplus.val.constants.PollStatusEnum;
+import no.haugalandplus.val.constants.UserTypeEnum;
+import no.haugalandplus.val.entities.Poll;
+import no.haugalandplus.val.entities.User;
+import no.haugalandplus.val.repository.PollRepository;
+import no.haugalandplus.val.repository.UserRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.UUID;
+
+@Service
+public class IoTService {
+
+    private PollRepository pollRepository;
+    private UserRepository userRepository;
+    private JwtTokenUtil jwtTokenUtil;
+
+    public IoTService(PollRepository pollRepository, UserRepository userRepository, JwtTokenUtil jwtTokenUtil) {
+        this.pollRepository = pollRepository;
+        this.userRepository = userRepository;
+        this.jwtTokenUtil = jwtTokenUtil;
+    }
+
+    public String addIotToPoll(Long pollId) {
+        Poll poll = pollRepository.findById(pollId).get();
+        if (poll.getStatus() != PollStatusEnum.NOT_INITIALISED) {
+            throw new RuntimeException("Can not add IoT-device to initiated polls");
+        }
+
+        User iot = new User();
+        iot.setUsername(UUID.randomUUID().toString());
+        iot.setUserType(UserTypeEnum.IOT);
+        iot = userRepository.save(iot);
+
+        poll.getIotList().add(iot);
+
+        pollRepository.save(poll);
+
+        return jwtTokenUtil.createJWT(iot.getUserId());
+    }
+
+    public void removeIot(List<User> iotList) {
+        userRepository.deleteAll(
+                iotList.stream()
+                    .filter(iot -> iot.getUserType() == UserTypeEnum.IOT)
+                    .toList()
+        );
+    }
+}

--- a/src/main/java/no/haugalandplus/val/service/PollService.java
+++ b/src/main/java/no/haugalandplus/val/service/PollService.java
@@ -88,9 +88,6 @@ public class PollService extends ServiceUtils {
 
         Poll poll = pollRepository.findById(pollId).get();
 
-//        if (vote.getChoice() poll.getChoices()) {
-//            throw new RuntimeException("Choice does not belong to poll");
-//        }
         if (poll.getStatus() != PollStatusEnum.ACTIVE) {
             throw new AccessDeniedException("Poll is not active. Has status " + poll.getStatus().toString());
         }

--- a/src/test/java/no/haugalandplus/val/TestUtils.java
+++ b/src/test/java/no/haugalandplus/val/TestUtils.java
@@ -13,11 +13,13 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 import java.util.Random;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.notNullValue;
 
 @SpringBootTest
 public class TestUtils {
@@ -85,5 +87,11 @@ public class TestUtils {
         assertThat(poll.getChoices(), hasSize(2));
 
         return poll;
+    }
+
+    public Poll startPoll(Poll poll) {
+        poll.setStatus(PollStatusEnum.ACTIVE);
+        poll.setStartTime(new Date());
+        return pollRepository.save(poll);
     }
 }

--- a/src/test/java/no/haugalandplus/val/service/IoTServiceTest.java
+++ b/src/test/java/no/haugalandplus/val/service/IoTServiceTest.java
@@ -1,0 +1,123 @@
+package no.haugalandplus.val.service;
+
+import io.jsonwebtoken.Claims;
+import no.haugalandplus.val.TestUtils;
+import no.haugalandplus.val.auth.JwtTokenUtil;
+import no.haugalandplus.val.constants.UserTypeEnum;
+import no.haugalandplus.val.dto.VoteDTO;
+import no.haugalandplus.val.entities.Poll;
+import no.haugalandplus.val.entities.User;
+import no.haugalandplus.val.entities.Vote;
+import no.haugalandplus.val.repository.PollRepository;
+import no.haugalandplus.val.repository.UserRepository;
+import no.haugalandplus.val.repository.VoteRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.fail;
+
+@SpringBootTest
+class IoTServiceTest extends TestUtils {
+
+    @Autowired
+    private IoTService ioTService;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private PollRepository pollRepository;
+
+    @Autowired
+    private JwtTokenUtil jwtTokenUtil;
+
+    @Autowired
+    private PollService pollService;
+
+    @Autowired
+    private VoteRepository voteRepository;
+
+
+    @Test
+    @Transactional
+    public void addIoT() {
+        Poll poll = saveNewPoll();
+        poll = addChoices(poll);
+
+        String token = ioTService.addIotToPoll(poll.getPollId());
+
+        Claims claims = jwtTokenUtil.isExpired(token);
+
+        User iot = userRepository.findById(Long.parseLong(claims.getSubject())).get();
+
+        assertThat(iot.getUserType(), is(UserTypeEnum.IOT));
+
+        poll = pollRepository.findById(poll.getPollId()).get();
+
+        assertThat(poll.getIotList(), hasSize(1));
+        assertThat(poll.getIotList().get(0).getUserId(), is(iot.getUserId()));
+
+        startPoll(poll);
+
+        try {
+            ioTService.addIotToPoll(poll.getPollId());
+            fail();
+        } catch (Exception e) {
+            assertThat(e, instanceOf(Exception.class));
+        }
+    }
+
+    @Test
+    @Transactional
+    public void addIoTVote() {
+        Poll poll = saveNewPoll();
+        poll = addChoices(poll);
+
+        String token = ioTService.addIotToPoll(poll.getPollId());
+
+        Claims claims = jwtTokenUtil.isExpired(token);
+
+        User iot = userRepository.findById(Long.parseLong(claims.getSubject())).get();
+
+        setSecurityContextUser(iot);
+
+        poll = startPoll(poll);
+
+        VoteDTO vote = new VoteDTO();
+        vote.setChoiceId(poll.getChoices().get(0).getChoiceId());
+        vote.setVoteCount(100L);
+
+        pollService.vote(poll.getPollId(), vote);
+
+        List<Vote> votes = voteRepository.findAll();
+        assertThat(votes, hasSize(1));
+        assertThat(votes.get(0).getVoteCount(), is(100));
+    }
+
+    @Test
+    @Transactional
+    public void testRemoveAll() {
+        Poll poll = saveNewPoll();
+        poll = addChoices(poll);
+
+        Long nrUsers = userRepository.count();
+
+        String token = ioTService.addIotToPoll(poll.getPollId());
+
+        assertThat(userRepository.count(), is(nrUsers+1));
+
+        Claims claims = jwtTokenUtil.isExpired(token);
+        User iot = userRepository.findById(Long.parseLong(claims.getSubject())).get();
+
+        ioTService.removeIot(userRepository.findAll());
+
+        assertThat(userRepository.count(), is(nrUsers));
+        assertThat(userRepository.existsByUsername(iot.getUsername()), is(false));
+    }
+}

--- a/src/test/java/no/haugalandplus/val/service/PollServiceTest.java
+++ b/src/test/java/no/haugalandplus/val/service/PollServiceTest.java
@@ -7,6 +7,7 @@ import no.haugalandplus.val.dto.VoteDTO;
 import no.haugalandplus.val.entities.Choice;
 import no.haugalandplus.val.entities.Poll;
 import no.haugalandplus.val.entities.User;
+import no.haugalandplus.val.entities.Vote;
 import no.haugalandplus.val.repository.ChoiceRepository;
 import no.haugalandplus.val.repository.PollRepository;
 import no.haugalandplus.val.repository.VoteRepository;
@@ -15,7 +16,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
@@ -126,7 +128,9 @@ class PollServiceTest extends TestUtils {
 
         pollService.vote(poll.getPollId(), vote);
 
-        assertThat(voteRepository.findAll(), hasSize(1));
+        List<Vote> votes = voteRepository.findAll();
+        assertThat(votes, hasSize(1));
+        assertThat(votes.get(0).getVoteCount(), is(1));
 
         PollDTO pollDTO = pollService.getPoll(poll.getPollId());
         assertThat(pollDTO.getChoices(), hasSize(2));


### PR DESCRIPTION
- A simple endpoint that gives you back a Jwt-token if it is a non-active poll. No need for a body. `GET /polls/{id}/iot`
- Same vote endpoint (not a list, I'm thinking about it. Might make a separate endpoint for IoT vote) but now it will accept multiple votes from IoT users
- All IoT-users are deleted when a poll is ended
- New API-documentation is missting